### PR TITLE
Add Steam Library Scanning for default install folder

### DIFF
--- a/app/actions/library.js
+++ b/app/actions/library.js
@@ -9,7 +9,7 @@ import GameGal from './../internals/Core/gamegal'
 import FileSystem from './../internals/Core/FileSystem'
 import ParsingService from "../internals/Games/ParsingService";
 import {store} from './../index'
-
+import Steam from './../internals/Core/Services/Steam'
 
 export const SET_CLOUD_GAMES = 'SET_CLOUD_GAMES';
 export const SET_INSTALLED_GAMES = 'SET_INSTALLED_GAMES';
@@ -99,4 +99,5 @@ export async function intiateGameSearch(installed_libraries=[]){
       }
     })
   });
+  Steam.commitSearchTransaction()
 }

--- a/app/internals/Core/FileSystem.js
+++ b/app/internals/Core/FileSystem.js
@@ -65,11 +65,8 @@ export default class FileSystem {
     }
     fs.readdirSync(slash(pathname)).forEach(filename => {
       const fileExt = FileSystem.getFileExtension(filename)
-      const full_path = `${folder.replace(/\\/g, '/')  }/${  filename}`
-      const isFile = fs.lstatSync(filename).isFile()
-      if (file_extensions instanceof string){
-        file_extensions = [file_extensions]
-      }
+      const full_path = `${slash(pathname).replace(/\\/g, '/')  }/${filename}`
+      const isFile = fs.lstatSync(full_path).isFile()
       if(file_extensions && file_extensions.includes(fileExt)){
         files.push(full_path)
       }

--- a/app/internals/Core/Services/Steam.js
+++ b/app/internals/Core/Services/Steam.js
@@ -1,0 +1,84 @@
+// @flow
+
+import os from 'os'
+import fs from 'fs'
+import {store} from './../../../index'
+import {setInstalledGames} from './../../../actions/library'
+import ParsingService from './../../Games/ParsingService'
+import GameGal from './../gamegal'
+import FileSystem from './../FileSystem'
+
+
+const OSType = os.type()
+const NONGAMES = ["Steamworks Common Redistributables"]
+
+export default class Steam {
+
+  static commitSearchTransaction(){
+    const vdfFiles = FileSystem.readFilesFromFolder(Steam.getDefaultSteamAppsLoc(), ['acf'])
+    this.readVdfGames(vdfFiles)
+  }
+
+  static async readVdfGames(filepaths){
+    const {library} = store.getState()
+    const {installed_games} = library
+    filepaths.forEach(filePath => {
+      fs.readFile(filePath, {encoding: 'utf-8'}, async function(err,data){
+        if (!err) {
+          //console.log('received data: ' + data);
+          const name = Steam.getVdfValue("name", data)
+          const appid = Steam.getVdfValue("appid", data)
+          const doesExist = await GameGal.find('Game', {launcher_id: appid})
+          if(NONGAMES.includes(name) || doesExist){
+            return
+          }
+          const foundGame = await ParsingService.matchGameFromPath(name + ".extension")
+          let saved_game;
+          if(foundGame){
+            saved_game = await GameGal.create('Game', { title:name, launcher_name: 'Steam',
+                                launcher_id: appid, nectar_id: foundGame.database_id })
+          }else{
+            // cant match so use existing file information
+            saved_game = await GameGal.create('Game', {launcher_id: appid, title: name, launcher_name: 'Steam' })
+          }
+          await GameGal.fetchAll('Game').then((collection) => {
+            store.dispatch(setInstalledGames(collection + [saved_game]))
+          })
+        } else {
+            console.error(err);
+        }
+      })
+    });
+  }
+
+
+  static getVdfValue(key, text){
+    var lines = text.split("\n"); // create array of lines
+    let value = null
+    lines.forEach((line) => {
+      if (line.includes(key)){
+        const foundLine = line.replace(`"${key}"`, "").replace(/"/gi, "")
+        value  = foundLine.trim()
+        console.log(value)
+      }
+    })
+    return value
+  }
+
+
+  static getDefaultSteamAppsLoc(){
+    switch(OSType){
+      case 'Windows_NT':
+        return "C:/Program Files (x86)/Steam/steamapps"
+      case 'Linux':
+        return ""
+      case 'Darwin': // MacOS
+        return "~/Library/Application Support/Steam/SteamApps/"
+      default:
+        return "C:/Program Files (x86)/Steam/steamapps"
+    }
+  }
+
+
+
+}


### PR DESCRIPTION
This PR adds Steam library scanning for the default install folder for games. This *DOES NOT* add Steam library support for custom user defined game libraries. This will be patched in follow-up PR for now I'll open up and issue for it so it doesn't get lost.